### PR TITLE
ci: Remove SSL from nginx testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN composer install --prefer-dist --no-dev --optimize-autoloader --no-interacti
 FROM php:8.2-fpm-alpine3.18 as prod
 
 ARG user=lolapi
-ARG uid=2000
-RUN adduser -u $uid -D $user
+RUN adduser -D $user
 
 WORKDIR /var/www
 
@@ -59,8 +58,7 @@ RUN composer install
 FROM php:8.2-fpm as dev
 
 ARG user=lolapi
-ARG uid=1000
-RUN useradd -G www-data,root -u $uid -d /home/$user $user
+RUN useradd -G www-data,root -d /home/$user $user
 
 WORKDIR /var/www
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
 
         $this->call([
             GameSeeder::class,
-            UserSeeder::class
+            // UserSeeder::class
         ]);
     }
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,7 +17,7 @@ services:
     networks:
       - lol-api
   app:
-    image: ghcr.io/phinocio/loadorderlibrary-api:testing
+    image: ghcr.io/phinocio/loadorderlibrary-api:latest
     container_name: lolapi-prod
     restart: unless-stopped
     entrypoint: sh -c "php artisan config:cache && php artisan route:cache && php artisan migrate && exec php-fpm"
@@ -51,7 +51,7 @@ services:
       - ./public:/var/www/public
       - ./docker/prod/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./docker/prod/nginx/sites-enabled:/etc/nginx/sites-enabled
-      - /var/log/nginx/lolapi-dev:/var/log/nginx
+      - /var/log/nginx/lolapi-prod:/var/log/nginx
     networks:
       - lol-api
     depends_on: [app]

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -29,13 +29,14 @@ services:
       APP_URL: ${APP_URL}
       FRONTEND_URL: ${FRONTEND_URL}
       SESSION_DOMAIN: ${SESSION_DOMAIN}
-      LOCAL_DOMAINS: ${LOCAL_DOMAINS}git
+      LOCAL_DOMAINS: ${LOCAL_DOMAINS}
       DB_CONNECTION: ${DB_CONNECTION}
       DB_HOST: ${DB_HOST}
       DB_PORT: ${DB_PORT}
       DB_DATABASE: ${DB_DATABASE}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
+    user: ${UID}:${GID}
     volumes:
       - ./storage/:/var/www/storage/
     networks:
@@ -46,29 +47,14 @@ services:
     container_name: lolapi-nginx
     restart: unless-stopped
     ports:
-      - "80:80"
-      - "443:443"
-      # - "8000:80"
+      - "8000:80"
     volumes:
       - ./public:/var/www/public
       - ./docker/testing/nginx/nginx.conf:/etc/nginx/nginx.conf
       - /var/log/nginx/lolapi-dev:/var/log/nginx
-      - certbot_etc:/etc/letsencrypt
-      - certbot_var:/var/lib/letsencrypt
-      - le_challenge:/var/www/_letsencrypt
-      - ./docker/testing/nginx/dhparam:/etc/nginx/dhparam
     networks:
       - lol-api
     depends_on: [app]
-  certbot:
-    image: certbot/certbot
-    container_name: certbot-api
-    volumes:
-      - certbot_etc:/etc/letsencrypt
-      - certbot_var:/var/lib/letsencrypt
-      - le_challenge:/var/www/_letsencrypt
-    depends_on: [nginx]
-    command: certonly --webroot -d dockertest2.loadorderlibrary.com --email letsencrypt@loadorderlibrary.com -w /var/www/_letsencrypt -n --agree-tos --force-renewal --no-eff-email --dry-run
 
 networks:
   lol-api:

--- a/docker/dev/nginx/dhparam/.gitignore
+++ b/docker/dev/nginx/dhparam/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/docker/prod/nginx/dhparam/.gitignore
+++ b/docker/prod/nginx/dhparam/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/docker/testing/nginx/dhparam/.gitignore
+++ b/docker/testing/nginx/dhparam/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/docker/testing/nginx/nginx.conf
+++ b/docker/testing/nginx/nginx.conf
@@ -33,39 +33,16 @@ http {
     access_log             off;
     error_log              /var/log/nginx/error.log warn;
 
-    # SSL
-    ssl_session_timeout    1d;
-    ssl_session_cache      shared:SSL:10m;
-    ssl_session_tickets    off;
-
-    # Diffie-Hellman parameter for DHE ciphersuites
-    ssl_dhparam            /etc/nginx/dhparam/dhparam.pem;
-
-    # Mozilla Intermediate configuration
-    ssl_protocols          TLSv1.2 TLSv1.3;
-    ssl_ciphers            ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-
-    # OCSP Stapling
-    ssl_stapling           on;
-    ssl_stapling_verify    on;
-    resolver               1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] 208.67.222.222 208.67.220.220 [2620:119:35::35] [2620:119:53::53] 9.9.9.9 149.112.112.112 [2620:fe::fe] [2620:fe::9] valid=60s;
-    resolver_timeout       2s;
-
     # Load configs
     include                /etc/nginx/conf.d/*.conf;
 
     # dockertest.loadorderlibrary.com
     server {
-        listen                               443 ssl http2;
-        listen                               [::]:443 ssl http2;
+        listen                               80;
+        listen                               [::]:80;
         server_name                          dockertest2.loadorderlibrary.com;
         set                                  $base /var/www;
         root                                 $base/public;
-
-        # SSL
-        ssl_certificate                      /etc/letsencrypt/live/dockertest2.loadorderlibrary.com/fullchain.pem;
-        ssl_certificate_key                  /etc/letsencrypt/live/dockertest2.loadorderlibrary.com/privkey.pem;
-        ssl_trusted_certificate              /etc/letsencrypt/live/dockertest2.loadorderlibrary.com/chain.pem;
 
         # security headers
         add_header X-XSS-Protection          "1; mode=block" always;
@@ -73,7 +50,6 @@ http {
         add_header Referrer-Policy           "no-referrer-when-downgrade" always;
         add_header Content-Security-Policy   "default-src 'self' http: https: ws: wss: data: blob: 'unsafe-inline'; frame-ancestors 'self';" always;
         add_header Permissions-Policy        "interest-cohort=()" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
         # . files
         location ~ /\.(?!well-known) {
@@ -139,22 +115,6 @@ http {
             fastcgi_param DOCUMENT_ROOT   $realpath_root;
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             fastcgi_param PHP_ADMIN_VALUE "open_basedir=$base/:/usr/lib/php/:/tmp/";
-        }
-    }
-
-    # HTTP redirect
-    server {
-        listen      80;
-        listen      [::]:80;
-        server_name dockertest2.loadorderlibrary.com;
-
-        # ACME-challenge
-        location ^~ /.well-known/acme-challenge/ {
-            root /var/www/_letsencrypt;
-        }
-
-        location / {
-            return 301 https://dockertest2.loadorderlibrary.com$request_uri;
         }
     }
 }


### PR DESCRIPTION
A reverse proxy will handle SSL on the servers, so it doesn't need to be in the nginx config for this.